### PR TITLE
DNSdump csrf_regex fix

### DIFF
--- a/turbolist3r.py
+++ b/turbolist3r.py
@@ -662,7 +662,7 @@ class DNSdumpster(enumratorBaseThreaded):
 		return self.get_response(resp)
 
 	def get_csrftoken(self, resp):
-		csrf_regex = re.compile("<input type='hidden' name='csrfmiddlewaretoken' value='(.*?)' />", re.S)
+		csrf_regex = re.compile('<input type="hidden" name="csrfmiddlewaretoken" value="(.*?)">', re.S)
 		token = csrf_regex.findall(resp)[0]
 		return token.strip()
 


### PR DESCRIPTION
DNSdump  csrf_regex fix/upgrade. 


--------------- Error  -----------------
```
Process DNSdumpster-8:
Traceback (most recent call last):
  File "/usr/lib/python2.7/multiprocessing/process.py", line 267, in _bootstrap
    self.run()
  File "/opt/Turbolist3r/turbolist3r.py", line 295, in run
    domain_list = self.enumerate()
  File "/opt/Turbolist3r/turbolist3r.py", line 671, in enumerate
    token = self.get_csrftoken(resp)
  File "/opt/Turbolist3r/turbolist3r.py", line 666, in get_csrftoken
    token = csrf_regex.findall(resp)[0]
IndexError: list index out of range
```
---------------------------------------------------
